### PR TITLE
Call callback for all responses

### DIFF
--- a/lib/purple/path.rb
+++ b/lib/purple/path.rb
@@ -51,6 +51,13 @@ module Purple
                    connection.post(url, params.to_json)
                  end
 
+      parsed_body = begin
+        JSON.parse(response.body)
+      rescue JSON::ParserError
+        response.body
+      end
+      client.callback&.call(url, params, headers, parsed_body)
+
       resp_structure = responses.find { |resp| resp.status_code == response.status }
 
       if resp_structure.nil?
@@ -63,8 +70,6 @@ module Purple
                  else
                    {}
                  end
-
-        client.callback&.call(url, params, headers, JSON.parse(response.body))
 
         if block_given?
           yield(resp_structure.status, object)


### PR DESCRIPTION
## Summary
- invoke the client callback regardless of HTTP status

## Testing
- `bundle exec rake` *(fails: Could not find gem 'rspec (~> 3.0)')*

------
https://chatgpt.com/codex/tasks/task_e_684b54daf838832aad62ff69ca20d3b9