### PR TITLE
Increase request timeout

### DIFF
--- a/lib/purple/path.rb
+++ b/lib/purple/path.rb
@@ -53,6 +53,8 @@ module Purple
 
       connection = Faraday.new(url: client.domain) do |conn|
         conn.headers = headers
+        conn.options.timeout = 600
+        conn.options.open_timeout = 600
       end
 
       unless client.domain.start_with?('http')


### PR DESCRIPTION
## Summary
- increase Faraday connection timeout and open_timeout to 600 seconds

## Testing
- `bundle exec rake spec` *(fails: Could not find gem 'rspec (~> 3.0)' in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_684b582cf32c832ab3ebbaf5076e5f61