### PR TITLE
Allow additional callback parameters

### DIFF
--- a/lib/purple/client.rb
+++ b/lib/purple/client.rb
@@ -43,6 +43,14 @@ module Purple
         end
       end
 
+      def callback_params(*args)
+        if args.empty?
+          @callback_params ||= []
+        else
+          @callback_params = args
+        end
+      end
+
       def path(name, method: :get, is_param: false)
         path = Path.new(name:, parent: @parent_path, method:, client: self, is_param:)
 

--- a/lib/purple/path.rb
+++ b/lib/purple/path.rb
@@ -81,7 +81,16 @@ module Purple
                    {}
                  end
 
-        client.callback&.call(url, params, headers, JSON.parse(response.body))
+        if client.callback
+          callback_args = [url, params, headers, JSON.parse(response.body)]
+          callback_args.concat(client.callback_params) if client.respond_to?(:callback_params)
+
+          if client.callback.lambda? && client.callback.arity >= 0
+            callback_args = callback_args.first(client.callback.arity)
+          end
+
+          client.callback.call(*callback_args)
+        end
 
         if block_given?
           yield(resp_structure.status, object)


### PR DESCRIPTION
## Summary
- support providing optional parameters for callbacks
- call callbacks with requested parameters respecting block arity

## Testing
- `bundle exec rake spec` *(fails: Could not find gem 'rspec (~> 3.0)' in locally installed gems)*
- `bundle exec rubocop` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff5e0b3c8832ab0baf2a04780b000