### PR TITLE
Improve README usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,109 @@
 # Purple::Client
 
-TODO: Delete this and the text below, and describe your gem
-
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/purple/client`. To experiment with that code, run `bin/console` for an interactive prompt.
+Purple::Client is a small DSL that helps you describe HTTP APIs. You define a domain, paths, and response structures, and the library generates handy methods for interacting with your service.
 
 ## Installation
 
-TODO: Replace `UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG` with your gem name right after releasing it to RubyGems.org. Please do not do it earlier due to security reasons. Alternatively, replace this section with instructions to install your gem from git if you don't plan to release to RubyGems.org.
-
-Install the gem and add to the application's Gemfile by executing:
+Add the gem to your project:
 
 ```bash
-bundle add UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG
+bundle add purple-client
 ```
 
-If bundler is not being used to manage dependencies, install the gem by executing:
+Or install it manually with:
 
 ```bash
-gem install UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG
+gem install purple-client
 ```
 
 ## Usage
 
-TODO: Write usage instructions here
+Below are some basic examples of how to define requests and call them.
+
+### Simple GET request
+
+```ruby
+Purple::Client.domain 'https://api.example.com'
+
+Purple::Client.path :status do
+  response :ok do
+    body :default
+  end
+  root_method :status
+end
+
+# Performs GET https://api.example.com/status
+Purple::Client.status
+```
+
+### Path with a dynamic parameter
+
+```ruby
+Purple::Client.path :jobs do
+  path :job_id, is_param: true do
+    response :ok do
+      body id: Integer, name: String
+    end
+    root_method :job
+  end
+end
+
+# Performs GET https://api.example.com/jobs/123
+Purple::Client.job(job_id: 123)
+```
+
+### Using authorization
+
+```ruby
+Purple::Client.authorization :bearer, 'TOKEN'
+
+Purple::Client.path :profile do
+  response :ok do
+    body :default
+  end
+  root_method :profile
+end
+
+# Authorization header will be sent automatically
+Purple::Client.profile
+```
+
+### Nested paths
+
+```ruby
+Purple::Client.path :users do
+  path :user_id, is_param: true do
+    path :posts do
+      response :ok do
+        body [{ id: Integer, title: String }]
+      end
+      root_method :user_posts
+    end
+  end
+end
+
+# Performs GET https://api.example.com/users/7/posts
+Purple::Client.user_posts(user_id: 7)
+```
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then run
+`rake spec` to execute the tests. You can also run `bin/console` for an interactive
+prompt to experiment with the library.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`.
+To release a new version, update the version number in `version.rb`, then run
+`bundle exec rake release`.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/purple-client. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/purple-client/blob/main/CODE_OF_CONDUCT.md).
+Bug reports and pull requests are welcome on GitHub at
+https://github.com/[USERNAME]/purple-client. Contributors are expected to adhere
+to the [code of conduct](https://github.com/[USERNAME]/purple-client/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+The gem is available as open source under the terms of the
+[MIT License](https://opensource.org/licenses/MIT).
 
-## Code of Conduct
-
-Everyone interacting in the Purple::Client project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/purple-client/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Summary
- replace the placeholder README with real documentation
- add examples showing how to define simple paths, dynamic segments and authorization
- include nested path usage

## Testing
- `bundle exec rake spec` *(fails: Could not find gem 'rspec (~> 3.0)' in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_6852786c2004832aa11163bd14a87491