### PR TITLE
Allow positional argument for param paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ class JobsClient < Purple::Client
 end
 
 # Performs GET https://api.example.com/jobs/123
-JobsClient.job(job_id: 123)
+JobsClient.job(123)
 ```
 
 ### Using authorization

--- a/lib/purple/client.rb
+++ b/lib/purple/client.rb
@@ -62,10 +62,16 @@ module Purple
       def root_method(method_name)
         current_path = @parent_path
 
-        define_singleton_method method_name do |**args, &block|
-          params = current_path.request.params.call(**args) if current_path.request.params.is_a?(Proc)
+        define_singleton_method method_name do |*call_args, **kw_args, &block|
+          if current_path.is_param
+            value = kw_args[current_path.name] || call_args.first
+            current_path.with(value)
+            kw_args[current_path.name] = value
+          end
 
-          current_path.execute(params, args, &block)
+          params = current_path.request.params.call(**kw_args) if current_path.request.params.is_a?(Proc)
+
+          current_path.execute(params, kw_args, &block)
         end
       end
 


### PR DESCRIPTION
## Summary
- support passing positional arguments to parameterized paths
- update README to demonstrate new usage

## Testing
- `bundle exec rake spec` *(fails: Could not find gem 'rspec (~> 3.0)' in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_6852808d46d8832a97a967ad29d031b5