### PR TITLE
Add custom headers example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,27 @@ end
 ProfileClient.profile
 ```
 
+### Using custom headers
+
+```ruby
+class CustomHeadersClient < Purple::Client
+  domain 'https://api.example.com'
+  authorization :custom_headers,
+                'X-API-KEY' => 'your-api-key',
+                'X-Secret' => 'your-api-secret'
+
+  path :widgets do
+    response :ok do
+      body :default
+    end
+    root_method :widgets
+  end
+end
+
+# Custom headers will be sent automatically
+CustomHeadersClient.widgets
+```
+
 ### Nested paths
 
 ```ruby


### PR DESCRIPTION
## Summary
- document `:custom_headers` authorization with example

## Testing
- `bundle exec rake spec` *(fails: Could not find gem 'rspec (~> 3.0)' in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_686c56a45ff0832ab82d22ea4eaddd47