### PR TITLE
Update README with boolean example

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,29 @@ extracted from the call and passed to your callback. In the example above the
 available inside the callback so you can associate the stored event with a
 record of your choice.
 
+### Boolean response types
+
+If you have boolean types `true` or `false` in your response, use
+`Purple::Boolean` in the response configuration.
+
+```ruby
+class AccountsClient < Purple::Client
+  domain 'https://api.example.com'
+
+  path :accounts do
+    response :ok do
+      body(
+        last_name: String,
+        first_name: String,
+        is_creator: Purple::Boolean,
+        is_premium: Purple::Boolean,
+      )
+    end
+    root_method :accounts
+  end
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then run


### PR DESCRIPTION
## Summary
- document how to use `Purple::Boolean` when a response includes booleans

## Testing
- `bundle exec rake spec` *(fails: Could not find gem 'rspec (~> 3.0)' in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_686c63a3a990832a8943b74ff08a63f9