### PR TITLE
Add README example specs

### DIFF
--- a/spec/purple/client_spec.rb
+++ b/spec/purple/client_spec.rb
@@ -4,8 +4,4 @@ RSpec.describe Purple::Client do
   it "has a version number" do
     expect(Purple::Client::VERSION).not_to be nil
   end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
 end

--- a/spec/readme_examples_spec.rb
+++ b/spec/readme_examples_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+RSpec.describe 'README examples' do
+  before do
+    stub_const('StoreEvent', Class.new do
+      def self.call(**args); end
+    end)
+
+    stub_const('SomeModel', Class.new do
+      def self.find(id)
+        id
+      end
+    end)
+  end
+
+  let(:executed) { [] }
+
+  around do |example|
+    allow_any_instance_of(Purple::Path).to receive(:execute) do |instance, params = {}, kw_args = {}, *callback_args|
+      executed << { path: instance.full_path, params: params, kw_args: kw_args, callback_args: callback_args }
+      :ok
+    end
+    example.run
+    %i[StatusClient JobsClient ProfileClient CustomHeadersClient PostsClient EventsClient AccountsClient CalendarClient].each do |const|
+      Object.send(:remove_const, const) if Object.const_defined?(const)
+    end
+  end
+
+  it 'evaluates code snippets from README' do
+    readme = File.read(File.expand_path('../README.md', __dir__))
+    snippets = readme.scan(/```ruby(.*?)```/m).map { |m| m.first.strip }
+    snippets.each do |code|
+      expect { eval(code) }.not_to raise_error
+    end
+
+    expect(executed).to include(hash_including(path: 'status'))
+    expect(executed).to include(hash_including(path: 'jobs/123'))
+    expect(executed).to include(hash_including(path: 'profile'))
+    expect(executed).to include(hash_including(path: 'widgets'))
+    expect(executed).to include(hash_including(path: 'users/7/posts'))
+    expect(executed).to include(hash_including(path: 'events'))
+    expect(executed).to include(hash_including(path: 'schedule'))
+  end
+end


### PR DESCRIPTION
## Summary
- ensure spec doesn't have failing placeholder
- add test to evaluate README examples and ensure requests are triggered

## Testing
- `rake spec` *(fails: cannot load such file -- rspec/core/rake_task)*

------
https://chatgpt.com/codex/tasks/task_e_686d977ba4a8832a924a608094075149