### PR TITLE
Document root_method limitation under nested params

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,36 @@ end
 PostsClient.user_posts(user_id: 7)
 ```
 
+### Paths nested under parameters
+
+When a path segment is marked with `is_param: true`, any paths nested
+inside it will not have a `root_method` generated. Instead of calling a
+root method, you need to chain the segment methods manually.
+
+```ruby
+class BrowserClient < Purple::Client
+  domain 'https://api.example.com'
+
+  path :browser do
+    path :id, is_param: true do
+      path :web, method: :post do
+        response :ok do
+        end
+
+        response :bad_request do
+          body do |res|
+            puts res
+          end
+        end
+      end
+    end
+  end
+end
+
+# root_method :web will not work here
+BrowserClient.browser.id('123').web
+```
+
 ### Callbacks with additional arguments
 
 ```ruby


### PR DESCRIPTION
## Summary
- clarify that root_method is not generated when nested under `is_param`
- show how to call such endpoints with chained methods

## Testing
- `bundle exec rake spec` *(fails: Could not find rake-13.3.0...)*


------
https://chatgpt.com/codex/tasks/task_e_689a9c16f494832a8eb5a3d766cb2b92