### PR TITLE
Add contain? helper and tests for optional response fields

### DIFF
--- a/lib/purple/responses/object.rb
+++ b/lib/purple/responses/object.rb
@@ -5,9 +5,9 @@ require 'active_support/core_ext/module/delegation'
 class Purple::Responses::Object
   attr_accessor :attributes
 
-  delegate :to_s, to: :attributes
+  delegate :to_s, :[], to: :attributes
 
   def contain?(key)
-    attributes.key?(key)
+    attributes.key?(key.to_sym) || attributes.key?(key.to_s)
   end
 end

--- a/spec/purple/responses/body_spec.rb
+++ b/spec/purple/responses/body_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require 'json'
+
+RSpec.describe Purple::Responses::Body do
+  let(:structure) do
+    {
+      name: String,
+      day: { type: Integer, optional: true }
+    }
+  end
+
+  context 'when optional field is missing' do
+    let(:body) { { name: 'John' }.to_json }
+    subject(:response) { described_class.new(structure:, response: nil).validate!(body, {}) }
+
+    it 'returns false for contain? on the missing field' do
+      expect(response.contain?(:day)).to eq(false)
+      expect(response.contain?('day')).to eq(false)
+    end
+
+    it 'raises NoMethodError when accessing the missing optional field' do
+      expect { response.day }.to raise_error(
+        NoMethodError,
+        "Optional field 'day' is not present in the response body. Use `contain?(:day)` to check its presence."
+      )
+    end
+  end
+
+  context 'when optional field is present' do
+    let(:body) { { name: 'John', day: 15 }.to_json }
+    subject(:response) { described_class.new(structure:, response: nil).validate!(body, {}) }
+
+    it 'allows access to the field and contain? returns true' do
+      expect(response.day).to eq(15)
+      expect(response.contain?(:day)).to eq(true)
+      expect(response.contain?('day')).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Allow checking presence of attributes with symbol or string keys via `contain?`
- Delegate `[]` to underlying attributes for hash-like access
- Add tests verifying optional response fields and `contain?` behavior

## Testing
- `bundle exec rspec spec/purple/responses/body_spec.rb` *(fails: bundler: command not found: rspec)*
- `bundle exec rubocop lib/purple/responses/object.rb spec/purple/responses/body_spec.rb` *(fails: bundler: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5a459ee0832aa5e8306acd1a8593